### PR TITLE
Updates README for bare repository setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ installed.
 
 ### Repository
 
-This plugin assumes that you have a `bare` repository setup for your worktrees. Before creating them, be sure you to clone a `bare` version of your repository as shown below:
+Currently, this plugin assumes that you have a `bare` repository setup for your worktrees. Before creating them, be sure you to clone a `bare` version of your repository as shown below. In the future, this will be handled automatically by the plugin.
 
 ```
 git clone --bare <upstream>

--- a/README.md
+++ b/README.md
@@ -19,6 +19,15 @@ Resource your vimrc and execute `PlugInstall` to ensure you have the plugin
 installed.
 
 ### Setup
+
+### Repository
+
+This plugin assumes that you have a `bare` repository setup for your worktrees. Before creating them, be sure you to clone a `bare` version of your repository as shown below:
+
+```
+git clone --bare <upstream>
+```
+
 #### Options
 `update_on_change`: Updates the current buffer to point to the new work tree if
 the file is found in the new project, else it will open up `:Ex` at the


### PR DESCRIPTION
This updates the documentation to include a precursor step of cloning a `bare` version of your working repository.