### PR TITLE
Change prompt_prefix to prompt_title

### DIFF
--- a/lua/telescope/_extensions/git_worktree.lua
+++ b/lua/telescope/_extensions/git_worktree.lua
@@ -97,7 +97,7 @@ end
 local telescope_git_worktree = function(opts)
     opts = opts or {}
     pickers.new({}, {
-        prompt_prefix = "Git Worktrees >",
+        prompt_title = "Git Worktrees",
         finder = finders.new_oneshot_job(vim.tbl_flatten({"git", "worktree", "list"}),
                                          opts),
         sorter = conf.generic_sorter({}),


### PR DESCRIPTION
For consistency with every other telescope picker and to not overwrite users' custom prompts.