### PR TITLE
Add the `change_directory_command` setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
 
 ## Options<a name="options"></a>
 
+`change_directory_command`: The vim command used to change to the new worktree directory.
+Set this to `tcd` if you want to only change the `pwd` for the current vim Tab.
+
 `update_on_change`:  Updates the current buffer to point to the new work tree if
 the file is found in the new project. Otherwise, the following command will be run.
 
@@ -86,6 +89,7 @@ edit the wrong files.
 
 ```lua
 require("git-worktree").setup({
+    change_directory_command = <str> -- default: "cd",
     update_on_change = <boolean> -- default: true,
     update_on_change_command = <str> -- default: "e .",
     clearjumps_on_change = <boolean> -- default: true,

--- a/lua/git-worktree/init.lua
+++ b/lua/git-worktree/init.lua
@@ -138,7 +138,7 @@ local function change_dirs(path)
 
     -- vim.loop.chdir(worktree_path)
     if Path:new(worktree_path):exists() then
-        local cmd = string.format("cd %s", worktree_path)
+        local cmd = string.format("%s %s", M._config.change_directory_command, worktree_path)
         status:log().debug("Changing to directory " .. worktree_path)
         vim.cmd(cmd)
         current_worktree_path = worktree_path
@@ -505,6 +505,7 @@ end
 M.setup = function(config)
     config = config or {}
     M._config = vim.tbl_deep_extend("force", {
+        change_directory_command = "cd",
         update_on_change = true,
         update_on_change_command = "e .",
         clearjumps_on_change = true,


### PR DESCRIPTION
Add the `change_directory_command` setting allowing to specify the Vim
command via which to switch to the worktree directory. Setting this to
`tcd` (for example) will only change the `pwd` for the current vim Tab.

Implement #44