### PR TITLE
Enable passing of telescope opts

### DIFF
--- a/lua/telescope/_extensions/git_worktree.lua
+++ b/lua/telescope/_extensions/git_worktree.lua
@@ -59,38 +59,35 @@ end
 
 local create_worktree = function(opts)
     opts = opts or {}
-    require("telescope.builtin").git_branches(
-        {
-            attach_mappings = function(_)
+    opts.attach_mappings = function()
+        actions.select_default:replace(
+            function(prompt_bufnr, _)
+                local selected_entry = action_state.get_selected_entry()
+                local current_line = action_state.get_current_line()
 
-                actions.select_default:replace(
-                    function(prompt_bufnr, _)
-                        local selected_entry = action_state.get_selected_entry()
-                        local current_line = action_state.get_current_line()
+                actions.close(prompt_bufnr)
 
-                        actions.close(prompt_bufnr)
+                local branch = selected_entry ~= nil and
+                    selected_entry.value or current_line
 
-                        local branch = selected_entry ~= nil and
-                            selected_entry.value or current_line
+                if branch == nil then
+                    return
+                end
 
-                        if branch == nil then
-                            return
-                        end
+                create_input_prompt(function(name)
+                    if name ~= "" then
+                        git_worktree.create_worktree(name, branch)
+                    else
+                        print("No path to create worktree")
+                    end
+                end)
+            end)
 
-                        create_input_prompt(function(name)
-                            if name ~= "" then
-                                git_worktree.create_worktree(name, branch)
-                            else
-                                print("No path to create worktree")
-                            end
-                        end)
-                    end)
+        -- do we need to replace other default maps?
 
-                -- do we need to replace other default maps?
-
-                return true
-            end
-        })
+        return true
+    end
+    require("telescope.builtin").git_branches(opts)
 end
 
 local telescope_git_worktree = function(opts)

--- a/lua/telescope/_extensions/git_worktree.lua
+++ b/lua/telescope/_extensions/git_worktree.lua
@@ -102,7 +102,7 @@ local telescope_git_worktree = function(opts)
     local parse_line = function(line)
         local fields = vim.split(string.gsub(line, "%s+", " "), " ")
         local entry = {
-            path = utils.transform_path(opts, fields[1]),
+            path = fields[1],
             sha = fields[2],
             branch = fields[3],
         }
@@ -110,7 +110,13 @@ local telescope_git_worktree = function(opts)
         if entry.sha ~= "(bare)" then
             local index = #results + 1
             for key, val in pairs(widths) do
-                widths[key] = math.max(val, strings.strdisplaywidth(entry[key] or ""))
+                if key == 'path' then
+                    new_path = utils.transform_path(opts, entry[key])
+                    path_len = strings.strdisplaywidth(new_path or "")
+                    widths[key] = math.max(val, path_len)
+                else
+                    widths[key] = math.max(val, strings.strdisplaywidth(entry[key] or ""))
+                end
             end
 
             table.insert(results, index, entry)
@@ -137,7 +143,7 @@ local telescope_git_worktree = function(opts)
     local make_display = function(entry)
         return displayer {
             { entry.branch, "TelescopeResultsIdentifier" },
-            { entry.path },
+            { utils.transform_path(opts, entry.path) },
             { entry.sha },
         }
     end

--- a/lua/telescope/_extensions/git_worktree.lua
+++ b/lua/telescope/_extensions/git_worktree.lua
@@ -59,7 +59,8 @@ local create_input_prompt = function(cb)
     cb(subtree)
 end
 
-local create_worktree = function()
+local create_worktree = function(opts)
+    opts = opts or {}
     require("telescope.builtin").git_branches(
         {
             attach_mappings = function(_)
@@ -95,12 +96,11 @@ local create_worktree = function()
 end
 
 local telescope_git_worktree = function(opts)
-    opts = opts or {}
-    pickers.new({}, {
+    pickers.new(opts or {}, {
         prompt_title = "Git Worktrees",
         finder = finders.new_oneshot_job(vim.tbl_flatten({"git", "worktree", "list"}),
                                          opts),
-        sorter = conf.generic_sorter({}),
+        sorter = conf.generic_sorter(opts),
         attach_mappings = function(_, map)
             action_set.select:replace(switch_worktree)
 

--- a/lua/telescope/_extensions/git_worktree.lua
+++ b/lua/telescope/_extensions/git_worktree.lua
@@ -102,7 +102,7 @@ local telescope_git_worktree = function(opts)
     local parse_line = function(line)
         local fields = vim.split(string.gsub(line, "%s+", " "), " ")
         local entry = {
-            path = fields[1],
+            path = utils.transform_path(opts, fields[1]),
             sha = fields[2],
             branch = fields[3],
         }
@@ -137,7 +137,7 @@ local telescope_git_worktree = function(opts)
     local make_display = function(entry)
         return displayer {
             { entry.branch, "TelescopeResultsIdentifier" },
-            { utils.transform_path(opts, entry.path) },
+            { entry.path },
             { entry.sha },
         }
     end


### PR DESCRIPTION
Can now pass `opts` to `create_git_worktree` and `git_worktrees` telescope extension in order to change layouts.
Had to switch out the `finders.new_oneshot_job` for a more custom finder following the design pattern used in Telescope git_branches.

![image](https://user-images.githubusercontent.com/66286082/129126040-1b4dd048-aa66-4e6c-a848-b14d2672b3ae.png)
![image](https://user-images.githubusercontent.com/66286082/129126053-ed112115-d82d-471b-a438-c0a3e67605fb.png)
