### PR TITLE
Fix issue with empty opts when calling transform_path

### DIFF
--- a/lua/telescope/_extensions/git_worktree.lua
+++ b/lua/telescope/_extensions/git_worktree.lua
@@ -91,6 +91,7 @@ local create_worktree = function(opts)
 end
 
 local telescope_git_worktree = function(opts)
+    opts = opts or {}
     local output = utils.get_os_command_output({"git", "worktree", "list"})
     local results = {}
     local widths = {


### PR DESCRIPTION
I had issues with empty opts when calling the git_worktree command. Empty opts were passed to telescope transform_path function and then it was indexed. Fixed it by using same line as in the create_worktree function.