### PR TITLE
Fix error message when launching vim from the bare repo

### DIFF
--- a/lua/git-worktree/init.lua
+++ b/lua/git-worktree/init.lua
@@ -75,7 +75,7 @@ M.setup_git_info = function()
     })
 
     local find_toplevel_bare_job = Job:new({
-        'git', 'worktree', 'list',
+        'git', 'rev-parse', '--is-bare-repository',
         cwd = cwd,
     })
 
@@ -85,13 +85,8 @@ M.setup_git_info = function()
     end
 
     local process_find_toplevel_bare = function(stdout)
-        local bare = "(bare)"
-        for _, line in pairs(stdout) do
-            if line and line:sub(-#bare) == bare then
-                current_worktree_path = vim.split(line, " ")[1]
-                status:log().debug("git toplevel is: " .. current_worktree_path)
-                return
-            end
+        if stdout == "true" then
+            current_worktree_path = cwd
         end
     end
 
@@ -121,8 +116,8 @@ M.setup_git_info = function()
     else
         stdout, code = find_toplevel_bare_job:sync()
         if code == 0 then
+            stdout = table.concat(stdout, "")
             process_find_toplevel_bare(stdout)
-            -- current_worktree_path = vim.inspect(stdout)
         else
             status:log().error("Error in determining the git toplevel")
             current_worktree_path = nil

--- a/tests/worktree_spec.lua
+++ b/tests/worktree_spec.lua
@@ -854,7 +854,7 @@ describe('git-worktree', function()
 
             git_worktree:setup_git_info()
             assert.are.same(vim.loop.cwd(), git_worktree:get_root())
-            assert.are.same(nil, git_worktree:get_current_worktree_path())
+            assert.are.same(vim.loop.cwd(), git_worktree:get_current_worktree_path())
 
         end))
 


### PR DESCRIPTION
When launching vim from a the root of a bare repo it would flash an error message:
```
[git-worktree-nvim] [ERROR 20:45:16] .../lua/git-worktree/init.lua:104: Error in determining the git toplevel
```
That would not break the functionality but was annoying.

Btw, I couldn't figure out what you were using for formatting, I guessed stylua with this config:
```toml
column_width = 120
line_endings = "Unix"
indent_type = "Spaces"
indent_width = 4
quote_style = "AutoPreferDouble"
no_call_parentheses = false
```
I've also moved some git related functionality into a git module, just to better organize myself, hope that's ok.