### PR TITLE
Add an example of using `on_tree_change` hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ can act on it.
 ```lua
 local Worktree = require("git-worktree")
 
--- op = Operation.Switch, Operation.Create, Operation.Delete
+-- op = Operations.Switch, Operations.Create, Operations.Delete
 -- metadata = table of useful values (structure dependent on op)
 --      Switch
 --          path = path you switched to
@@ -168,6 +168,9 @@ local Worktree = require("git-worktree")
 --          path = path where worktree deleted
 
 Worktree.on_tree_change(function(op, metadata)
+  if op == Worktree.Operations.Switch then
+    print("Switched from " .. metadata.prev_path .. " to " .. metadata.path)
+  end
 end)
 ```
 


### PR DESCRIPTION
I had trouble figuring out how to use `Operation.Switch`. It turns out the docs said singular `Operation` but the actual enum is `Operations`. I also wasn't sure how to access the enum (even though in hindsight it is very obvious).

An example like the one I added would have saved me a few minutes.