### PR TITLE
Allow confirmation requirement for deletions via telescope

### DIFF
--- a/lua/git-worktree/init.lua
+++ b/lua/git-worktree/init.lua
@@ -523,6 +523,8 @@ M.setup = function(config)
         update_on_change = true,
         update_on_change_command = "e .",
         clearjumps_on_change = true,
+        -- default to false to avoid breaking the previous default behavior
+        confirm_telescope_deletions = false,
         -- should this default to true or false?
         autopush = false,
     }, config)

--- a/lua/telescope/_extensions/git_worktree.lua
+++ b/lua/telescope/_extensions/git_worktree.lua
@@ -24,9 +24,14 @@ local switch_worktree = function(prompt_bufnr)
 end
 
 local confirm_deletion = function()
+  if not git_worktree._config.confirm_telescope_deletions then
+    return true
+  end
+
   local confirmation = vim.fn.input(
       string.format("Delete worktree? [y/n]: ")
   )
+
   if string.sub(string.lower(confirmation), 0, 1) == "y" then
       return true
   end

--- a/lua/telescope/_extensions/git_worktree.lua
+++ b/lua/telescope/_extensions/git_worktree.lua
@@ -23,7 +23,23 @@ local switch_worktree = function(prompt_bufnr)
     end
 end
 
+local confirm_deletion = function()
+  local confirmation = vim.fn.input(
+      string.format("Delete worktree? [y/n]: ")
+  )
+  if string.sub(string.lower(confirmation), 0, 1) == "y" then
+      return true
+  end
+
+  print("Didn't delete worktree")
+  return false
+end
+
 local delete_worktree = function(prompt_bufnr, force)
+    if not confirm_deletion() then
+        return
+    end
+
     local worktree_path = get_worktree_path(prompt_bufnr)
     actions.close(prompt_bufnr)
     if worktree_path ~= nil then


### PR DESCRIPTION
I used the confirmation logic from ThePrimeagen/harpoon as a template, and added a configuration option to opt-in to the new feature.