### PR TITLE
(WIP) Fix telescope deletion forcing

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+indent_style = space
+indent_size = 4
+insert_final_newline = true


### PR DESCRIPTION
@polarmutex this PR is on the right track for how I think we could handle forced deletions from the telescope extension. Unfortunately, we apparently can't call vimL functions (`vim.fn.input`) from a lua loop callback (which I think is another way of saying an async job).

Do you have any ideas how we could address it? I thought about printing:

"Deletion failed, try again to force delete"

and then automatically force deleting if the user deletes the same worktree a second time in a row. I think this is a little too magical, but so far I don't have any other ideas.