### PR TITLE
feat: expose git_worktree telescope actions

### DIFF
--- a/lua/telescope/_extensions/git_worktree.lua
+++ b/lua/telescope/_extensions/git_worktree.lua
@@ -12,6 +12,8 @@ local git_worktree = require("git-worktree")
 
 local force_next_deletion = false
 
+local wt_actions = {}
+
 local get_worktree_path = function(prompt_bufnr)
     local selection = action_state.get_selected_entry(prompt_bufnr)
     return selection.path
@@ -25,7 +27,7 @@ local switch_worktree = function(prompt_bufnr)
     end
 end
 
-local toggle_forced_deletion = function()
+wt_actions.toggle_forced_deletion = function()
     -- redraw otherwise the message is not displayed when in insert mode
     if force_next_deletion then
         print('The next deletion will not be forced')
@@ -68,7 +70,7 @@ local confirm_deletion = function(forcing)
     return false
 end
 
-local delete_worktree = function(prompt_bufnr)
+wt_actions.delete_worktree = function(prompt_bufnr)
     if not confirm_deletion() then
         return
     end
@@ -215,10 +217,10 @@ local telescope_git_worktree = function(opts)
         attach_mappings = function(_, map)
             action_set.select:replace(switch_worktree)
 
-            map("i", "<c-d>", delete_worktree)
-            map("n", "<c-d>", delete_worktree)
-            map("i", "<c-f>", toggle_forced_deletion)
-            map("n", "<c-f>", toggle_forced_deletion)
+            map("i", "<c-d>", wt_actions.delete_worktree)
+            map("n", "<c-d>", wt_actions.delete_worktree)
+            map("i", "<c-f>", wt_actions.toggle_forced_deletion)
+            map("n", "<c-f>", wt_actions.toggle_forced_deletion)
 
             return true
         end
@@ -229,6 +231,7 @@ return require("telescope").register_extension(
            {
         exports = {
             git_worktrees = telescope_git_worktree,
-            create_git_worktree = create_worktree
+            create_git_worktree = create_worktree,
+            actions = wt_actions
         }
     })


### PR DESCRIPTION
Exposes `delete_worktree` and `toggle_forced_deletion` to uses via `require('telescope').extensions.git_worktree.actions.[action_name]`.

This will enable users to rebind those actions to different keys easily.

I don't know why I didn't think to do this apart of #80 but if/once that gets merged in, people will be able to set mappings in the telescope `setup()` function. I can tweak the readme so show that when the time comes. 
