### PR TITLE
Add `update_on_worktree_change` config option, and depreacte `update_on_change_command`

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,9 @@ Set this to `tcd` if you want to only change the `pwd` for the current vim Tab.
 `update_on_change`:  Updates the current buffer to point to the new work tree if
 the file is found in the new project. Otherwise, the following command will be run.
 
-`update_on_change_command`: The vim command to run during the `update_on_change` event.
-Note, that this command will only be run when the current file is not found in the new worktree.
-This option defaults to `e .` which opens the root directory of the new worktree.
+`update_on_new_worktree`: The lua function to be run after changing the working
+directory to the new worktree. The default function is to update the current
+buffer to the equivalent file in the new worktree.
 
 `clearjumps_on_change`: Every time you switch branches, your jumplist will be
 cleared so that you don't accidentally go backward to a different branch and
@@ -87,11 +87,16 @@ edit the wrong files.
 
 `autopush`: When creating a new worktree, it will push the branch to the upstream then perform a `git rebase`
 
+*DEPRECATED*
+`update_on_change_command`: The vim command to run during the `update_on_change` event.
+Note, that this command will only be run when the current file is not found in the new worktree.
+This option defaults to `e .` which opens the root directory of the new worktree.
+
 ```lua
 require("git-worktree").setup({
     change_directory_command = <str> -- default: "cd",
     update_on_change = <boolean> -- default: true,
-    update_on_change_command = <str> -- default: "e .",
+    update_on_new_worktree = <function(op, metadata)> -- default: `update_current_buffer_with_fallback`,
     clearjumps_on_change = <boolean> -- default: true,
     autopush = <boolean> -- default: false,
 })

--- a/lua/git-worktree/init.lua
+++ b/lua/git-worktree/init.lua
@@ -129,7 +129,7 @@ local function update_current_buffer_with_fallback(op, metadata)
     if not changed then
         status:log().debug("Could not change to the file in the new worktree, running `e .`")
         if M._config.update_on_change_command then
-            status:log().warn("`update_on_change_command` will be soon be deprecated. Use `update_on_new_worktree` instead.")
+            status:log().warn("`update_on_change_command` will be soon be deprecated. Use `update_on_worktree_change` instead.")
             vim.cmd(M._config.update_on_change_command)
             return
         end
@@ -140,7 +140,7 @@ end
 local function on_tree_change_handler(op, metadata)
     if M._config.update_on_change then
         if op == Enum.Operations.Switch then
-            M._config.update_on_new_worktree(op, metadata)
+            M._config.update_on_worktree_change(op, metadata)
         end
     end
 end
@@ -547,7 +547,7 @@ M.setup = function(config)
         change_directory_command = "cd",
         update_on_change = true,
         update_on_change_command = nil,
-        update_on_new_worktree = update_current_buffer_with_fallback,
+        update_on_worktree_change = update_current_buffer_with_fallback,
         clearjumps_on_change = true,
         -- default to false to avoid breaking the previous default behavior
         confirm_telescope_deletions = false,

--- a/lua/git-worktree/init.lua
+++ b/lua/git-worktree/init.lua
@@ -124,14 +124,23 @@ M.setup_git_info = function()
 
 end
 
+local function update_current_buffer_with_fallback(op, metadata)
+    local changed = M.update_current_buffer(metadata["prev_path"])
+    if not changed then
+        status:log().debug("Could not change to the file in the new worktree, running `e .`")
+        if M._config.update_on_change_command then
+            status:log().warn("`update_on_change_command` will be soon be deprecated. Use `update_on_new_worktree` instead.")
+            vim.cmd(M._config.update_on_change_command)
+            return
+        end
+        vim.cmd("e .")
+    end
+end
+
 local function on_tree_change_handler(op, metadata)
     if M._config.update_on_change then
         if op == Enum.Operations.Switch then
-            local changed = M.update_current_buffer(metadata["prev_path"])
-            if not changed then
-                status:log().debug("Could not change to the file in the new worktree, running the `update_on_change_command`")
-                vim.cmd(M._config.update_on_change_command)
-            end
+            M._config.update_on_new_worktree(op, metadata)
         end
     end
 end
@@ -537,7 +546,8 @@ M.setup = function(config)
     M._config = vim.tbl_deep_extend("force", {
         change_directory_command = "cd",
         update_on_change = true,
-        update_on_change_command = "e .",
+        update_on_change_command = nil,
+        update_on_new_worktree = update_current_buffer_with_fallback,
         clearjumps_on_change = true,
         -- default to false to avoid breaking the previous default behavior
         confirm_telescope_deletions = false,


### PR DESCRIPTION
This pull request allows for more control over what happens when the current working directory is changed to the specified worktree. A workaround was mentioned in #13 , but it isn't ideal since `git-worktree` would always run the code to open the current buffer in the specified worktree. With the changes in this PR, the workaround can be achieved without running unnecessary code.

No breaking changes are introduced, and users won't experience any different behavior with their current configs. But the assumption was made that this would lead to the eventual deprecation of `on_change_command`. This can be discussed, because I don't feel strongly about it.

I use `auto-session` for managing sessions, but any session-manager/code can be used here. A sample configuration is below.

```
local worktree = require("git-worktree")

local update_on_worktree_change = function(op, metadata)
	vim.api.nvim_command("RestoreSession")
end

require("git-worktree").setup({
	clear_jumps_on_change = false, -- this is handled by auto-session
	update_on_worktree_change = update_on_worktree_change,
})
```