### PR TITLE
Add option to disable fetching on branch creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ edit the wrong files.
 
 `autopush`: When creating a new worktree, it will push the branch to the upstream then perform a `git rebase`
 
+`fetch_on_create`: When creating a new worktree, do a git fetch. Defaults to true
+
 ```lua
 require("git-worktree").setup({
     change_directory_command = <str> -- default: "cd",
@@ -94,6 +96,7 @@ require("git-worktree").setup({
     update_on_change_command = <str> -- default: "e .",
     clearjumps_on_change = <boolean> -- default: true,
     autopush = <boolean> -- default: false,
+    fetch_on_create = <boolean> -- default: true,
 })
 ```
 


### PR DESCRIPTION
I had this code commented out for the past half year; time to formalise the option so others can use it.

For me, an additional fetch is really annoying because it adds more than 10 seconds to this workflow which I use multiple times per day, and I already have a different binding to fetch explicitly.

Default behaviour unchanged; add this to your config to skip fetch (also updated the docs):
```
require("git-worktree").setup({
    fetch_on_create = false
})
```