### PR TITLE
fix: `:Telescope git_worktree`

### DIFF
--- a/lua/telescope/_extensions/git_worktree.lua
+++ b/lua/telescope/_extensions/git_worktree.lua
@@ -228,6 +228,7 @@ end
 return require("telescope").register_extension(
            {
         exports = {
+            git_worktree = telescope_git_worktree,
             git_worktrees = telescope_git_worktree,
             create_git_worktree = create_worktree
         }


### PR DESCRIPTION
Prior to this fix, one would obtain the following rather cryptic error when attempting to run `:Telescope git_worktree`
```
Error executing Lua callback: ...ck/minpac/start/telescope.nvim/lua/telescope/command.lua:193: attempt to call a nil value
stack traceback:
        ...ck/minpac/start/telescope.nvim/lua/telescope/command.lua:193: in function 'run_command'
        ...ck/minpac/start/telescope.nvim/lua/telescope/command.lua:253: in function 'load_command'
        ...im/pack/minpac/start/telescope.nvim/plugin/telescope.lua:109: in function <...im/pack/minpac/start/telescope.nvim/plugin/telescope.lua:108>
```

The reason for this, is that telescope assumes, that the main command of an extension is identical to its name: https://github.com/nvim-telescope/telescope.nvim/blob/30e2dc5232d0dd63709ef8b44a5d6184005e8602/lua/telescope/command.lua#L193

Instead of renaming the existing `git_worktrees` command (which would likely break every users' config) I opted to duplicate the command under the expected name