### PR TITLE
fix: dont set origin prefix 2 times

### DIFF
--- a/lua/git-worktree/init.lua
+++ b/lua/git-worktree/init.lua
@@ -174,9 +174,15 @@ local function create_worktree_job(path, branch, found_branch)
     local worktree_add_args = {'worktree', 'add'}
 
     if not found_branch then
-        table.insert(worktree_add_args, '-b')
-        table.insert(worktree_add_args, branch)
-        table.insert(worktree_add_args, path)
+        if branch:find('^origin/') then
+            table.insert(worktree_add_args, path)
+            local local_branch_name = branch:gsub("origin/", "")
+            table.insert(worktree_add_args, local_branch_name)
+        else
+            table.insert(worktree_add_args, '-b')
+            table.insert(worktree_add_args, branch)
+            table.insert(worktree_add_args, path)
+        end
     else
         table.insert(worktree_add_args, path)
         table.insert(worktree_add_args, branch)


### PR DESCRIPTION
Hello!

When creating a new worktree from a remote ref the `origin/` prefix is added 2 times to the tracking branch.
`git worktree` can handle the case that one tracking branch exists when a new worktree should be created.
The PR fixes the Issue #77

```
If <commit-ish> is a branch name (call it <branch>) and is not found, and neither -b nor -B nor --detach are used, but there does exist a tracking branch in exactly one remote (call it <remote>) with a matching name, treat as equivalent to:

$ git worktree add --track -b <branch> <path> <remote>/<branch>
```

Links:
- https://git-scm.com/docs/git-worktree