### PR TITLE
Fix for issue 122: doesn't show worktrees with telescope 0.1.6                               

### DIFF
--- a/lua/telescope/_extensions/git_worktree.lua
+++ b/lua/telescope/_extensions/git_worktree.lua
@@ -76,15 +76,14 @@ local delete_worktree = function(prompt_bufnr)
     local worktree_path = get_worktree_path(prompt_bufnr)
     actions.close(prompt_bufnr)
     if worktree_path ~= nil then
-       git_worktree.delete_worktree(worktree_path, force_next_deletion, {
-           on_failure = delete_failure_handler,
-           on_success = delete_success_handler
-       })
+        git_worktree.delete_worktree(worktree_path, force_next_deletion, {
+            on_failure = delete_failure_handler,
+            on_success = delete_success_handler
+        })
     end
 end
 
 local create_input_prompt = function(cb)
-
     --[[
     local window = Window.centered({
         width = 30,
@@ -143,7 +142,7 @@ end
 
 local telescope_git_worktree = function(opts)
     opts = opts or {}
-    local output = utils.get_os_command_output({"git", "worktree", "list"})
+    local output = utils.get_os_command_output({ "git", "worktree", "list" })
     local results = {}
     local widths = {
         path = 0,
@@ -194,9 +193,9 @@ local telescope_git_worktree = function(opts)
 
     local make_display = function(entry)
         return displayer {
-            { entry.branch, "TelescopeResultsIdentifier" },
-            { utils.transform_path(opts, entry.path) },
-            { entry.sha },
+            { entry.branch,                           "TelescopeResultsIdentifier" },
+            { utils.transform_path(opts, entry.path), "TelescopeResultsIdentifier" },
+            { entry.sha,                              "TelescopeResultsIdentifier" },
         }
     end
 
@@ -226,7 +225,7 @@ local telescope_git_worktree = function(opts)
 end
 
 return require("telescope").register_extension(
-           {
+    {
         exports = {
             git_worktree = telescope_git_worktree,
             git_worktrees = telescope_git_worktree,


### PR DESCRIPTION
This PR fixes the "worktrees not showing" issue described in the issue 122 by setting the `hl_group` for all the `display_highlights` returned by the `make_display` function.

I am not a Telescope, neovim nor lua expert so please feel free to give feedback/better implementation for the fix.

The linting changes were made by `lua_ls` I can revert those if the changes are not welcome.