### PR TITLE
Handle changes in the Telescope API

### DIFF
--- a/lua/telescope/_extensions/git_worktree.lua
+++ b/lua/telescope/_extensions/git_worktree.lua
@@ -193,9 +193,10 @@ local telescope_git_worktree = function(opts)
     }
 
     local make_display = function(entry)
+        local path, _ = utils.transform_path(opts, entry.path)
         return displayer {
             { entry.branch, "TelescopeResultsIdentifier" },
-            { utils.transform_path(opts, entry.path) },
+            { path },
             { entry.sha },
         }
     end


### PR DESCRIPTION
Eliminate an incompatibility introduced by [commit](https://github.com/nvim-telescope/telescope.nvim/commit/a4432dfb9b0b960c4cbc8765a42dc4fe2e029e8f) in the Telescope repository, where `utils.transform_path()` began returning multiple `display` and `path_style` values instead of a single `display` value.