### PR TITLE
Avoid editing an empty buffer on startup

### DIFF
--- a/lua/git-worktree/init.lua
+++ b/lua/git-worktree/init.lua
@@ -537,7 +537,7 @@ M.setup = function(config)
     M._config = vim.tbl_deep_extend("force", {
         change_directory_command = "cd",
         update_on_change = true,
-        update_on_change_command = "e .",
+        update_on_change_command = "if expand('%:t') != '' | e . | endif",
         clearjumps_on_change = true,
         -- default to false to avoid breaking the previous default behavior
         confirm_telescope_deletions = false,


### PR DESCRIPTION
Currently, switching to the worktree after opening Nvim without any path arguments (without an open file in the current window) results in an unnamed buffer being created with the path to the current directory ("." is a directory).

With this change, the command to update a currently open file from a path in a switched worktree is executed only if the buffer in the current window has a name (saved as a file).