### PR TITLE
feat: fix change when path contains any spaces

### DIFF
--- a/lua/git-worktree/init.lua
+++ b/lua/git-worktree/init.lua
@@ -152,7 +152,8 @@ local function change_dirs(path)
 
     -- vim.loop.chdir(worktree_path)
     if Path:new(worktree_path):exists() then
-        local cmd = string.format("%s %s", M._config.change_directory_command, worktree_path)
+        local escaped_path = string.gsub(worktree_path, "%s", "\\ ")
+        local cmd = string.format("%s %s", M._config.change_directory_command, escaped_path)
         status:log().debug("Changing to directory " .. worktree_path)
         vim.cmd(cmd)
         current_worktree_path = worktree_path
@@ -207,6 +208,13 @@ local function has_worktree(path, cb)
             end
 
             data = list_data[1]
+
+            if #data > 3 then
+                data = list_data[1]
+                for i = 2, #list_data - 2 do
+                    data = data .. ' ' .. list_data[i]
+                end
+            end
 
             local start
             if plenary_path:is_absolute() then

--- a/lua/telescope/_extensions/git_worktree.lua
+++ b/lua/telescope/_extensions/git_worktree.lua
@@ -153,11 +153,23 @@ local telescope_git_worktree = function(opts)
 
     local parse_line = function(line)
         local fields = vim.split(string.gsub(line, "%s+", " "), " ")
+
         local entry = {
             path = fields[1],
             sha = fields[2],
             branch = fields[3],
         }
+
+        if #fields > 3 then
+            local path = fields[1]
+            for i = 2, #fields - 2 do
+                path = path .. ' ' .. fields[i]
+            end
+
+            entry.path = path
+            entry.sha = fields[#fields - 1]
+            entry.branch = fields[#fields]
+        end
 
         if entry.sha ~= "(bare)" then
             local index = #results + 1


### PR DESCRIPTION
This should fix #114

Despite having folder names with spaces is really abnormal, I saw people complaining about that. So I decided to fix that problem

I don't know the rules if there are for creating PRs

My solution is quite simple, whenever a path is processed from `git worktree list` command I changed the way it is processed, if there are more than 3 parts (I assume that the path contains at least one space) I join the parts with a space to get the correct path again.

Disclaimer: I do not know a lot of lua, I did my best with my knowledge.