### PR TITLE
Allow changing directory with lua command

### DIFF
--- a/lua/git-worktree/init.lua
+++ b/lua/git-worktree/init.lua
@@ -157,7 +157,7 @@ local function change_dirs(path)
         vim.cmd(cmd)
         current_worktree_path = worktree_path
     else
-        status:error('Could not chang to directory: ' ..worktree_path)
+        status:error('Could not change to directory: ' ..worktree_path)
     end
 
     if M._config.clearjumps_on_change then

--- a/lua/git-worktree/init.lua
+++ b/lua/git-worktree/init.lua
@@ -152,7 +152,7 @@ local function change_dirs(path)
 
     -- vim.loop.chdir(worktree_path)
     if Path:new(worktree_path):exists() then
-        local cmd = string.format("%s %s", M._config.change_directory_command, worktree_path)
+        local cmd = string.format("%s '%s'", M._config.change_directory_command, worktree_path)
         status:log().debug("Changing to directory " .. worktree_path)
         vim.cmd(cmd)
         current_worktree_path = worktree_path

--- a/lua/telescope/_extensions/git_worktree.lua
+++ b/lua/telescope/_extensions/git_worktree.lua
@@ -193,9 +193,10 @@ local telescope_git_worktree = function(opts)
     }
 
     local make_display = function(entry)
+        local path, _ = utils.transform_path(opts, entry.path)
         return displayer {
             { entry.branch, "TelescopeResultsIdentifier" },
-            { utils.transform_path(opts, entry.path) },
+            { path },
             { entry.sha },
         }
     end


### PR DESCRIPTION
Allows setting `"lua some_lua_cmd"` as the `change_directory_command`. Previously this was not possible because the directory would be evaluated as a command instead of as an argument.
