### PR TITLE
fix:🐛 paths not normalized for windows

### DIFF
--- a/lua/git-worktree/init.lua
+++ b/lua/git-worktree/init.lua
@@ -210,12 +210,11 @@ local function has_worktree(path, cb)
 
             local start
             if plenary_path:is_absolute() then
-                start = data == path
+                start = data == vim.fs.normalize(path)
             else
-                local worktree_path = Path:new(
+                local worktree_path = vim.fs.normalize(Path:new(
                     string.format("%s" .. Path.path.sep .. "%s", git_worktree_root, path)
-                )
-                worktree_path = worktree_path:absolute()
+                ):absolute())
                 start = data == worktree_path
             end
 


### PR DESCRIPTION
## Description
Running `:lua require("git-worktree").create_worktree("nvim-btw","main","origin")` on windows results in an error

The `has_worktree` function does not work on windows. When it tries to compare the output from `git worktree list` with the calculated path for the newly created worktree it does not get a match.

After adding some print statements, i see the following. 

```
## init.lua #L229
{                                                                                                                                              
  case = "worktree_path:absolute",                                                                                                             
  data = "C:/Users/Gustav/repo/test/cli-devkit.git/abffff",                                                                                    
  path = "C:/Users/Gustav/repo/test/cli-devkit.git\\abffff"                                                                                  
} 
```

## Reproduce

1. Use windows
2. Clone a bare repo
3. Open neovim btw
4. Run `:lua require("git-worktree").create_worktree("nvim-btw","main","origin")`
You will recieve the following error message
![image](https://github.com/user-attachments/assets/e7775a1d-12d6-4be8-a499-eb90ea9baa01)



## Additional

My code only normalizes the path but it is worth considering using vims inbuilt api for concatenating paths
The call to `:absolute()` seems redundant on windows as it returns an absolute path but perhaps not on linux?
```diff
- vim.fs.normalize(Path:new(string.format("%s" .. Path.path.sep .. "%s", git_worktree_root, path)):absolute())
+ vim.fs.joinpath(git_worktree_root, path)
```
