### PR TITLE
fix(telescope):🐛 worktree list crashing

### DIFF
--- a/lua/telescope/_extensions/git_worktree.lua
+++ b/lua/telescope/_extensions/git_worktree.lua
@@ -76,15 +76,14 @@ local delete_worktree = function(prompt_bufnr)
     local worktree_path = get_worktree_path(prompt_bufnr)
     actions.close(prompt_bufnr)
     if worktree_path ~= nil then
-       git_worktree.delete_worktree(worktree_path, force_next_deletion, {
-           on_failure = delete_failure_handler,
-           on_success = delete_success_handler
-       })
+        git_worktree.delete_worktree(worktree_path, force_next_deletion, {
+            on_failure = delete_failure_handler,
+            on_success = delete_success_handler
+        })
     end
 end
 
 local create_input_prompt = function(cb)
-
     --[[
     local window = Window.centered({
         width = 30,
@@ -143,7 +142,7 @@ end
 
 local telescope_git_worktree = function(opts)
     opts = opts or {}
-    local output = utils.get_os_command_output({"git", "worktree", "list"})
+    local output = utils.get_os_command_output({ "git", "worktree", "list" })
     local results = {}
     local widths = {
         path = 0,
@@ -193,9 +192,10 @@ local telescope_git_worktree = function(opts)
     }
 
     local make_display = function(entry)
+        local path = utils.transform_path(opts, entry.path)
         return displayer {
             { entry.branch, "TelescopeResultsIdentifier" },
-            { utils.transform_path(opts, entry.path) },
+            { path },
             { entry.sha },
         }
     end
@@ -226,7 +226,7 @@ local telescope_git_worktree = function(opts)
 end
 
 return require("telescope").register_extension(
-           {
+    {
         exports = {
             git_worktree = telescope_git_worktree,
             git_worktrees = telescope_git_worktree,

--- a/lua/telescope/_extensions/git_worktree.lua
+++ b/lua/telescope/_extensions/git_worktree.lua
@@ -76,14 +76,15 @@ local delete_worktree = function(prompt_bufnr)
     local worktree_path = get_worktree_path(prompt_bufnr)
     actions.close(prompt_bufnr)
     if worktree_path ~= nil then
-        git_worktree.delete_worktree(worktree_path, force_next_deletion, {
-            on_failure = delete_failure_handler,
-            on_success = delete_success_handler
-        })
+       git_worktree.delete_worktree(worktree_path, force_next_deletion, {
+           on_failure = delete_failure_handler,
+           on_success = delete_success_handler
+       })
     end
 end
 
 local create_input_prompt = function(cb)
+
     --[[
     local window = Window.centered({
         width = 30,
@@ -142,7 +143,7 @@ end
 
 local telescope_git_worktree = function(opts)
     opts = opts or {}
-    local output = utils.get_os_command_output({ "git", "worktree", "list" })
+    local output = utils.get_os_command_output({"git", "worktree", "list"})
     local results = {}
     local widths = {
         path = 0,
@@ -226,7 +227,7 @@ local telescope_git_worktree = function(opts)
 end
 
 return require("telescope").register_extension(
-    {
+           {
         exports = {
             git_worktree = telescope_git_worktree,
             git_worktrees = telescope_git_worktree,


### PR DESCRIPTION
This was a weird bug and I want someone to confirm that it also happens on their machines.

When running `require('telescope').extensions.git_worktree.git_worktrees()` it opens a telescope picker with no entries. 
Checking `:messages` gives the following output

```
[telescope] [WARN  20:03:04] C:/Users/Gustav/AppData/Local/nvim-data/lazy/telescope.nvim/lua/telescope/pickers.lua:672: Finder failed with msg:  ...lazy/telescope.nvim/lua/telescope/pickers/highlights.lua:33: Invalid 'hl_group': Expected Lua string
```

This is weird right?

Turns out that this function is the culprit
```lua
    local make_display = function(entry)
        return displayer {
            { entry.branch, "TelescopeResultsIdentifier" },
            { utils.transform_path(opts, entry.path) },
            { entry.sha },
        }
    end
```
Can you spot the bug?

Turns out `utils.transform_path` has more than one return value, meaning that if you do something like this
`local path, arg = utils.transform_path(a,b)` returns the following `"abc", {} `. Given the way this function is inlined into the arguments of the displayer it captures both values instead of only the intended string. Thus giving you the error of `Expected Lua string`.

Easily fixed by just discarding the second return value
```lua
 local make_display = function(entry)
        local path = utils.transform_path(opts, entry.path)
        return displayer {
            { entry.branch, "TelescopeResultsIdentifier" },
            { path },
            { entry.sha },
        }
    end

```
