### PR TITLE
Fix: use empty strings explicitly for path and sha

### DIFF
--- a/lua/telescope/_extensions/git_worktree.lua
+++ b/lua/telescope/_extensions/git_worktree.lua
@@ -195,8 +195,8 @@ local telescope_git_worktree = function(opts)
     local make_display = function(entry)
         return displayer {
             { entry.branch, "TelescopeResultsIdentifier" },
-            { utils.transform_path(opts, entry.path) },
-            { entry.sha },
+            { utils.transform_path(opts, entry.path), "" },
+            { entry.sha, "" },
         }
     end
 


### PR DESCRIPTION
When using 
:lua require('telescope').extensions.git_worktree.git_worktrees()
A warn message occurs and picker does not function normally (doesn't pick first element by default and doesn't show all elements)
```log
Invalid 'hl_group': Expected Lua string
```
This change sets "" (empty string) as a fallback for non-highlighted fields to avoid undefined behaviour.
